### PR TITLE
fishing improvements.

### DIFF
--- a/constants/item_constants.asm
+++ b/constants/item_constants.asm
@@ -84,7 +84,7 @@ SAFARI_ROCK EQU $16 ; overload
 	const POKE_FLUTE    ; $49
 	const LIFT_KEY      ; $4A
 	const EXP_ALL       ; $4B
-	const SUPER_ROD     ; $4C
+	const FISHING_ROD     ; $4C
 	const PP_UP         ; $4D
 	const ETHER         ; $4E
 	const MAX_ETHER     ; $4F

--- a/data/items/key_items.asm
+++ b/data/items/key_items.asm
@@ -75,7 +75,7 @@ KeyItemFlags:
 	dbit TRUE  ; POKE_FLUTE
 	dbit TRUE  ; LIFT_KEY
 	dbit FALSE ; EXP_ALL
-	dbit TRUE  ; SUPER_ROD
+	dbit TRUE  ; FISHING_ROD
 	dbit FALSE ; PP_UP
 	dbit FALSE ; ETHER
 	dbit FALSE ; MAX_ETHER

--- a/data/items/prices.asm
+++ b/data/items/prices.asm
@@ -75,7 +75,7 @@ ItemPrices::
 	bcd3 0     ; POKE_FLUTE
 	bcd3 0     ; LIFT_KEY
 	bcd3 0     ; EXP_ALL
-	bcd3 0     ; SUPER_ROD
+	bcd3 0     ; FISHING_ROD
 	bcd3 0     ; PP_UP
 	bcd3 0     ; ETHER
 	bcd3 0     ; MAX_ETHER

--- a/data/items/use_overworld.asm
+++ b/data/items/use_overworld.asm
@@ -3,5 +3,5 @@ UsableItems_CloseMenu:
 	db ESCAPE_ROPE
 	db ITEMFINDER
 	db POKE_FLUTE
-	db SUPER_ROD
+	db FISHING_ROD
 	db -1 ; end

--- a/data/wild/fishing_rod.asm
+++ b/data/wild/fishing_rod.asm
@@ -1,5 +1,5 @@
 ; super rod encounters
-SuperRodData:
+FishingRodData:
 	; map, fishing group
 	dbw PALLET_TOWN,         .Group1
 	dbw VIRIDIAN_CITY,       .Group2
@@ -38,185 +38,215 @@ SuperRodData:
 
 ; fishing groups
 ; number of monsters, followed by level/monster pairs
+; max 16.
 
-; PALLET TOWN
+; PALLET TOWN 
 .Group1:
-	db 6
-	db 8, MAGIKARP
-	db 10, GOLDEEN
-	db 9, GOLDEEN
+	db 12 ; 25% no bite
+	db 5, MAGIKARP
+	db 6, MAGIKARP
 	db 7, MAGIKARP
+	db 8, MAGIKARP
+	db 5, GOLDEEN
+	db 6, GOLDEEN
+	db 7, GOLDEEN
+	db 8, GOLDEEN
 	db 5, TENTACOOL
 	db 6, TENTACOOL
+	db 7, TENTACOOL
+	db 8, TENTACOOL
 
 ; VIRIDIAN 
 .Group2:
-	db 6
-	db 12, MAGIKARP
-	db 11, GOLDEEN
-	db 10, GOLDEEN
-	db 11, POLIWAG
-	db 10, POLIWAG
+	db 12 ; 25% no bite
+	db 7, MAGIKARP
+	db 8, MAGIKARP
+	db 9, MAGIKARP
 	db 10, MAGIKARP
+	db 8, GOLDEEN
+	db 9, GOLDEEN
+	db 10, GOLDEEN
+	db 11, GOLDEEN
+	db 8, POLIWAG
+	db 9, POLIWAG
+	db 10, POLIWAG
+	db 11, POLIWAG
 
 ; CERULEAN
 .Group3:
-	db 8
-	db 13, MAGIKARP
-	db 12, GOLDEEN
-	db 11, GOLDEEN
-	db 13, POLIWAG
-	db 12, POLIWAG
+	db 12 ; 25% no bite
+	db 11, MAGIKARP
 	db 12, MAGIKARP
-	db 8, SLOWPOKE
+	db 13, MAGIKARP
+	db 11, GOLDEEN
+	db 12, GOLDEEN
+	db 13, GOLDEEN
+	db 12, POLIWAG
+	db 13, POLIWAG
 	db 9, SLOWPOKE
+	db 10, SLOWPOKE
+	db 10, PSYDUCK
+	db 11, PSYDUCK
 
 ; VERMILLION
 .Group4:
-	db 8
-	db 13, KRABBY
+	db 12 ; 25% no bite
 	db 12, KRABBY
-	db 14, SHELLDER
+	db 13, KRABBY
+	db 14, KRABBY
+	db 15, KRABBY
+	db 12, SHELLDER
 	db 13, SHELLDER
-	db 11, HORSEA
-	db 12, HORSEA
-	db 15, STARYU
-	db 16, STARYU
+	db 14, SHELLDER
+	db 15, SHELLDER
+	db 12, SLOWPOKE
+	db 13, SLOWPOKE
+	db 14, SLOWPOKE
+	db 15, SLOWPOKE
 
 ; CELADON
 .Group5:
-	db 8
-	db 18, POLIWAG
+	db 10 ; 37.5% no bite
 	db 19, POLIWAG
-	db 15, GRIMER
-	db 14, GRIMER
-	db 19, MAGIKARP
-	db 18, MAGIKARP
+	db 20, POLIWAG
+	db 21, POLIWAG
+	db 18, GRIMER
+	db 19, GRIMER
+	db 20, GRIMER
 	db 17, MAGIKARP
-	db 22, POLIWHIRL
+	db 18, MAGIKARP
+	db 19, MAGIKARP
+	db 25, POLIWHIRL
 
 ; POLLUTED RIVER
 .Group6:
-	db 8
+	db 12 ; 25% no bite
 	db 16, MAGIKARP
+	db 17, MAGIKARP
+	db 18, MAGIKARP
+	db 16, GOLDEEN
 	db 17, GOLDEEN
 	db 18, GOLDEEN
 	db 15, POLIWAG
+	db 16, POLIWAG
 	db 17, POLIWAG
-	db 17, MAGIKARP
-	db 13, GRIMER
 	db 14, GRIMER
+	db 15, GRIMER
+	db 16, GRIMER
 
 ; RIVER
 .Group7:
-	db 8
+	db 12 ; 25% no bite
+	db 13, MAGIKARP
+	db 14, MAGIKARP
 	db 15, MAGIKARP
+	db 13, GOLDEEN
 	db 14, GOLDEEN
 	db 15, GOLDEEN
-	db 15, POLIWAG
 	db 13, POLIWAG
-	db 14, MAGIKARP
-	db 13, SLOWPOKE
-	db 12, SLOWPOKE
+	db 14, POLIWAG
+	db 15, POLIWAG
+	db 14, SLOWPOKE
+	db 15, SLOWPOKE
+	db 16, SLOWPOKE
 
 ; COASTAL ROUTES
 .Group8:
-	db 8
+	db 12 ; 25% no bite
 	db 19, KRABBY
 	db 20, KRABBY
-	db 19, SHELLDER
+	db 21, KRABBY
 	db 18, SHELLDER
-	db 17, HORSEA
+	db 19, SHELLDER
+	db 20, SHELLDER
+	db 18, HORSEA
 	db 19, HORSEA
-	db 18, STARYU
+	db 20, HORSEA
 	db 19, STARYU
-	db 17, SEEL
-	db 18, SEEL
+	db 20, STARYU
+	db 21, STARYU
 
 ; FUSHICA BEACH
 .Group9:
-	db 10
+	db 14 ; 12.5% no bite
+	db 22, KRABBY
 	db 23, KRABBY
-	db 25, KRABBY
+	db 24, KRABBY
+	db 22, SHELLDER
+	db 23, SHELLDER
 	db 24, SHELLDER
-	db 25, SHELLDER
-	db 26, HORSEA
-	db 25, HORSEA
-	db 25, STARYU
+	db 21, HORSEA
+	db 22, HORSEA
+	db 23, HORSEA
+	db 23, STARYU
 	db 24, STARYU
-	db 24, SEEL
-	db 23, SEEL
-	db 22, TENTACOOL
-	db 24, TENTACOOL
+	db 25, STARYU
+	db 28, KINGLER
+	db 29, KINGLER
 
 ; FUSCHIA
 .Group10:
-	db 8
-	db 23, POLIWHIRL
-	db 25, POLIWHIRL
+	db 13 ; 18.75% no bite
+	db 22, GOLDEEN
+	db 23, GOLDEEN
 	db 24, GOLDEEN
-	db 26, GOLDEEN
-	db 28, SEAKING
+	db 22, POLIWAG
+	db 23, POLIWAG
+	db 24, POLIWAG
+	db 22, MAGIKARP
 	db 23, MAGIKARP
 	db 24, MAGIKARP
-	db 28, GYARADOS
+	db 28, POLIWHIRL
+	db 29, POLIWHIRL
+	db 30, GYARADOS
+	db 32, GYARADOS
 
 ; OPEN OCEAN
 .Group11:
-	db 14
+	db 14 ; 12.5% no bite
 	db 27, SHELLDER
 	db 28, SHELLDER
-	db 30, HORSEA
-	db 29, HORSEA
+	db 29, SHELLDER
 	db 28, HORSEA
-	db 30, STARYU
+	db 29, HORSEA
+	db 30, HORSEA
 	db 28, STARYU
-	db 28, SEEL
-	db 27, SEEL
-	db 29, TENTACOOL
-	db 30, TENTACOOL
+	db 29, STARYU
+	db 30, STARYU
+	db 27, TENTACOOL
 	db 28, TENTACOOL
-	db 34, TENTACRUEL
+	db 29, TENTACOOL
+	db 33, TENTACRUEL
 	db 35, SEADRA
 
 ; CINNABAR
 .Group12:
-	db 22
-	db 29, KRABBY
-	db 28, KRABBY
-	db 30, KRABBY
+	db 14 ; 12.5% no bite
+	db 27, SHELLDER
+	db 28, SHELLDER
 	db 29, SHELLDER
-	db 30, SHELLDER
-	db 31, SHELLDER
+	db 28, HORSEA
 	db 29, HORSEA
 	db 30, HORSEA
-	db 31, HORSEA
-	db 29, STARYU
-	db 30, STARYU
-	db 31, STARYU
-	db 29, TENTACOOL
-	db 30, TENTACOOL
-	db 31, TENTACOOL
+	db 28, GRIMER
+	db 29, GRIMER
 	db 30, GRIMER
-	db 31, GRIMER
-	db 32, GRIMER
-	db 36, SEADRA
-	db 35, KINGLER
-	db 34, TENTACRUEL
+	db 27, TENTACOOL
+	db 28, TENTACOOL
+	db 29, TENTACOOL
+	db 33, TENTACRUEL
+	db 35, SEADRA
 	db 36, MUK
 
 ; SAFARI
 .Group13:
-	db 20
+	db 16 ; guaranteed pokemon
 	db 31, PSYDUCK
 	db 30, PSYDUCK
 	db 29, PSYDUCK
 	db 30, SLOWPOKE
 	db 32, SLOWPOKE
 	db 31, SLOWPOKE
-	db 30, MAGIKARP
-	db 33, MAGIKARP
-	db 32, MAGIKARP
 	db 30, SEAKING
 	db 33, SEAKING
 	db 32, SEAKING
@@ -227,17 +257,12 @@ SuperRodData:
 	db 36, SLOWBRO
 	db 37, GYARADOS
 	db 25, DRATINI
-	db 26, DRATINI
 
 ; SEAFOAM
 .Group14:
-	db 19
+	db 14 ; 12.5% no bite
 	db 33, KINGLER
 	db 34, KINGLER
-	db 35, KINGLER
-	db 33, SLOWPOKE
-	db 34, SLOWPOKE
-	db 35, SLOWPOKE
 	db 33, STARYU
 	db 34, STARYU
 	db 35, STARYU
@@ -249,12 +274,11 @@ SuperRodData:
 	db 32, SEEL
 	db 38, CLOYSTER
 	db 38, STARMIE
-	db 39, SLOWBRO
 	db 39, DEWGONG
 
 ; POKEMON LEAGUE
 .Group15:
-	db 13
+	db 13 ; 18.5% no bite
 	db 39, SLOWBRO
 	db 40, SLOWBRO
 	db 41, SLOWBRO
@@ -264,24 +288,26 @@ SuperRodData:
 	db 39, GOLDUCK
 	db 40, GOLDUCK
 	db 41, GOLDUCK
-	db 40, GYARADOS
-	db 41, GYARADOS
+	db 40, SEADRA
+	db 41, SEADRA
 	db 42, GYARADOS
 	db 30, DRATINI
 
 ; CERULEAN CAVE
 .Group16:
-	db 13
-	db 45, SLOWBRO
-	db 46, SLOWBRO
-	db 47, SLOWBRO
-	db 45, SEAKING
-	db 46, SEAKING
-	db 47, SEAKING
-	db 45, GOLDUCK
-	db 46, GOLDUCK
-	db 47, GOLDUCK
-	db 47, GYARADOS
-	db 48, GYARADOS
-	db 49, GYARADOS
-	db 39, DRAGONAIR
+	db 15 ; 6.25% miss rate
+	db 55, SLOWBRO
+	db 56, SLOWBRO
+	db 57, SLOWBRO
+	db 55, SEAKING
+	db 56, SEAKING
+	db 57, SEAKING
+	db 55, GOLDUCK
+	db 56, GOLDUCK
+	db 57, GOLDUCK
+	db 57, SEADRA
+	db 58, SEADRA
+	db 59, GYARADOS
+	db 55, CLOYSTER
+	db 55, STARMIE
+	db 44, DRAGONAIR

--- a/data/wild/good_rod.asm
+++ b/data/wild/good_rod.asm
@@ -1,5 +1,0 @@
-; random choice of 2 good rod encounters
-GoodRodMons:
-	; level, species
-	db 10, GOLDEEN
-	db 10, POLIWAG

--- a/data/wild/grass_water.asm
+++ b/data/wild/grass_water.asm
@@ -1,14 +1,14 @@
 WildDataPointers:
 	table_width 2, WildDataPointers
-	dw NothingWildMons         ; PALLET_TOWN
-	dw NothingWildMons         ; VIRIDIAN_CITY
+	dw PalletTownWildMons      ; PALLET_TOWN
+	dw ViridianCityWildMons    ; VIRIDIAN_CITY
 	dw NothingWildMons         ; PEWTER_CITY
-	dw NothingWildMons         ; CERULEAN_CITY
+	dw CeruleanCityWildMons    ; CERULEAN_CITY
 	dw NothingWildMons         ; LAVENDER_TOWN
-	dw NothingWildMons         ; VERMILION_CITY
-	dw NothingWildMons         ; CELADON_CITY
-	dw NothingWildMons         ; FUCHSIA_CITY
-	dw NothingWildMons         ; CINNABAR_ISLAND
+	dw VermilionCityWildMons   ; VERMILION_CITY
+	dw CeladonCityWildMons     ; CELADON_CITY
+	dw FuchsiaCityWildMons     ; FUCHSIA_CITY
+	dw CinnabarIslandWildMons  ; CINNABAR_ISLAND
 	dw NothingWildMons         ; INDIGO_PLATEAU
 	dw NothingWildMons         ; SAFFRON_CITY
 	dw NothingWildMons         ; unused
@@ -30,8 +30,8 @@ WildDataPointers:
 	dw Route16WildMons         ; ROUTE_16
 	dw Route17WildMons         ; ROUTE_17
 	dw Route18WildMons         ; ROUTE_18
-	dw SeaRoutesWildMons       ; ROUTE_19
-	dw SeaRoutesWildMons       ; ROUTE_20
+	dw Route19WildMons         ; ROUTE_19
+	dw Route20WildMons         ; ROUTE_20
 	dw Route21WildMons         ; ROUTE_21
 	dw Route22WildMons         ; ROUTE_22
 	dw Route23WildMons         ; ROUTE_23
@@ -66,7 +66,7 @@ WildDataPointers:
 	dw NothingWildMons
 	dw NothingWildMons
 	dw NothingWildMons
-	dw NothingWildMons
+	dw CeruleanGymWildMons
 	dw NothingWildMons
 	dw NothingWildMons
 	dw NothingWildMons
@@ -95,7 +95,7 @@ WildDataPointers:
 	dw NothingWildMons
 	dw NothingWildMons
 	dw NothingWildMons
-	dw NothingWildMons
+	dw VermilionDockWildMons
 	dw NothingWildMons
 	dw NothingWildMons
 	dw NothingWildMons
@@ -261,8 +261,16 @@ WildDataPointers:
         ; first byte is encounter rate
         ; followed by 20 bytes:
         ; level, species (ten times)
+; adding a 3rd space for fishing mons, solely for pokedex tracking
 
 INCLUDE "data/wild/maps/nothing.asm"
+INCLUDE "data/wild/maps/PalletTown.asm"
+INCLUDE "data/wild/maps/ViridianCity.asm"
+INCLUDE "data/wild/maps/CeruleanCity.asm"
+INCLUDE "data/wild/maps/VermilionCity.asm"
+INCLUDE "data/wild/maps/CeladonCity.asm"
+INCLUDE "data/wild/maps/FuchsiaCity.asm"
+INCLUDE "data/wild/maps/CinnabarIsland.asm"
 INCLUDE "data/wild/maps/Route1.asm"
 INCLUDE "data/wild/maps/Route2.asm"
 INCLUDE "data/wild/maps/Route22.asm"
@@ -297,11 +305,12 @@ INCLUDE "data/wild/maps/Route15.asm"
 INCLUDE "data/wild/maps/Route16.asm"
 INCLUDE "data/wild/maps/Route17.asm"
 INCLUDE "data/wild/maps/Route18.asm"
+INCLUDE "data/wild/maps/Route19.asm"
+INCLUDE "data/wild/maps/Route20.asm"
 INCLUDE "data/wild/maps/SafariZoneCenter.asm"
 INCLUDE "data/wild/maps/SafariZoneEast.asm"
 INCLUDE "data/wild/maps/SafariZoneNorth.asm"
 INCLUDE "data/wild/maps/SafariZoneWest.asm"
-INCLUDE "data/wild/maps/SeaRoutes.asm"
 INCLUDE "data/wild/maps/SeafoamIslands1F.asm"
 INCLUDE "data/wild/maps/SeafoamIslandsB1F.asm"
 INCLUDE "data/wild/maps/SeafoamIslandsB2F.asm"
@@ -319,5 +328,7 @@ INCLUDE "data/wild/maps/PowerPlant.asm"
 INCLUDE "data/wild/maps/Route23.asm"
 INCLUDE "data/wild/maps/VictoryRoad2F.asm"
 INCLUDE "data/wild/maps/VictoryRoad3F.asm"
+INCLUDE "data/wild/maps/CeruleanGym.asm"
+INCLUDE "data/wild/maps/VermilionDock.asm"
 INCLUDE "data/wild/maps/VictoryRoad1F.asm"
 INCLUDE "data/wild/maps/DiglettsCave.asm"

--- a/data/wild/maps/CeladonCity.asm
+++ b/data/wild/maps/CeladonCity.asm
@@ -1,0 +1,19 @@
+CeladonCityWildMons:
+	def_grass_wildmons 0 ; encounter rate
+	end_grass_wildmons
+
+	def_water_wildmons 0 ; encounter rate
+	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, POLIWAG
+	db 1, GRIMER
+	db 1, MAGIKARP
+	db 1, POLIWHIRL
+	db 1, POLIWHIRL
+	db 1, POLIWHIRL
+	db 1, POLIWHIRL
+	db 1, POLIWHIRL
+	db 1, POLIWHIRL
+	db 1, POLIWHIRL
+	end_fishing_wildmons

--- a/data/wild/maps/CeruleanCave1F.asm
+++ b/data/wild/maps/CeruleanCave1F.asm
@@ -19,3 +19,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, SLOWBRO
+	db 1, SEAKING
+	db 1, GOLDUCK
+	db 1, SEADRA
+	db 1, GYARADOS
+	db 1, CLOYSTER
+	db 1, STARMIE
+	db 1, DRAGONAIR
+	db 1, DRAGONAIR
+	db 1, DRAGONAIR
+	end_fishing_wildmons

--- a/data/wild/maps/CeruleanCave2F.asm
+++ b/data/wild/maps/CeruleanCave2F.asm
@@ -14,3 +14,16 @@ CeruleanCave2FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, SLOWBRO
+	db 1, SEAKING
+	db 1, GOLDUCK
+	db 1, SEADRA
+	db 1, GYARADOS
+	db 1, CLOYSTER
+	db 1, STARMIE
+	db 1, DRAGONAIR
+	db 1, DRAGONAIR
+	db 1, DRAGONAIR
+	end_fishing_wildmons

--- a/data/wild/maps/CeruleanCaveB1F.asm
+++ b/data/wild/maps/CeruleanCaveB1F.asm
@@ -19,3 +19,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, SLOWBRO
+	db 1, SEAKING
+	db 1, GOLDUCK
+	db 1, SEADRA
+	db 1, GYARADOS
+	db 1, CLOYSTER
+	db 1, STARMIE
+	db 1, DRAGONAIR
+	db 1, DRAGONAIR
+	db 1, DRAGONAIR
+	end_fishing_wildmons

--- a/data/wild/maps/CeruleanCity.asm
+++ b/data/wild/maps/CeruleanCity.asm
@@ -1,0 +1,19 @@
+CeruleanCityWildMons:
+	def_grass_wildmons 0 ; encounter rate
+	end_grass_wildmons
+
+	def_water_wildmons 0 ; encounter rate
+	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, MAGIKARP
+	db 1, GOLDEEN
+	db 1, POLIWAG
+	db 1, SLOWPOKE
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	end_fishing_wildmons

--- a/data/wild/maps/CeruleanGym.asm
+++ b/data/wild/maps/CeruleanGym.asm
@@ -1,0 +1,19 @@
+CeruleanGymWildMons:
+	def_grass_wildmons 0 ; encounter rate
+	end_grass_wildmons
+
+	def_water_wildmons 0 ; encounter rate
+	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, MAGIKARP
+	db 1, GOLDEEN
+	db 1, POLIWAG
+	db 1, SLOWPOKE
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	end_fishing_wildmons

--- a/data/wild/maps/CinnabarIsland.asm
+++ b/data/wild/maps/CinnabarIsland.asm
@@ -1,0 +1,19 @@
+CinnabarIslandWildMons:
+	def_grass_wildmons 0 ; encounter rate
+	end_grass_wildmons
+
+	def_water_wildmons 0 ; encounter rate
+	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, SHELLDER
+	db 1, HORSEA
+	db 1, GRIMER
+	db 1, TENTACOOL
+	db 1, TENTACRUEL
+	db 1, SEADRA
+	db 1, MUK
+	db 1, MUK
+	db 1, MUK
+	db 1, MUK
+	end_fishing_wildmons

--- a/data/wild/maps/DiglettsCave.asm
+++ b/data/wild/maps/DiglettsCave.asm
@@ -14,3 +14,6 @@ DiglettsCaveWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/FuchsiaCity.asm
+++ b/data/wild/maps/FuchsiaCity.asm
@@ -1,0 +1,19 @@
+FuchsiaCityWildMons:
+	def_grass_wildmons 0 ; encounter rate
+	end_grass_wildmons
+
+	def_water_wildmons 0 ; encounter rate
+	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, GOLDEEN
+	db 1, POLIWAG
+	db 1, MAGIKARP
+	db 1, POLIWHIRL
+	db 1, GYARADOS
+	db 1, GYARADOS
+	db 1, GYARADOS
+	db 1, GYARADOS
+	db 1, GYARADOS
+	db 1, GYARADOS
+	end_fishing_wildmons

--- a/data/wild/maps/MtMoon1F.asm
+++ b/data/wild/maps/MtMoon1F.asm
@@ -14,3 +14,6 @@ MtMoon1FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/MtMoonB1F.asm
+++ b/data/wild/maps/MtMoonB1F.asm
@@ -14,3 +14,6 @@ MtMoonB1FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/MtMoonB2F.asm
+++ b/data/wild/maps/MtMoonB2F.asm
@@ -14,3 +14,6 @@ MtMoonB2FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/PalletTown.asm
+++ b/data/wild/maps/PalletTown.asm
@@ -1,0 +1,19 @@
+PalletTownWildMons:
+	def_grass_wildmons 0 ; encounter rate
+	end_grass_wildmons
+
+	def_water_wildmons 0 ; encounter rate
+	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, MAGIKARP
+	db 1, GOLDEEN
+	db 1, TENTACOOL
+	db 1, TENTACOOL
+	db 1, TENTACOOL
+	db 1, TENTACOOL
+	db 1, TENTACOOL
+	db 1, TENTACOOL
+	db 1, TENTACOOL
+	db 1, TENTACOOL
+	end_fishing_wildmons

--- a/data/wild/maps/PokemonMansion1F.asm
+++ b/data/wild/maps/PokemonMansion1F.asm
@@ -28,3 +28,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/PokemonMansion2F.asm
+++ b/data/wild/maps/PokemonMansion2F.asm
@@ -28,3 +28,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/PokemonMansion3F.asm
+++ b/data/wild/maps/PokemonMansion3F.asm
@@ -28,3 +28,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/PokemonMansionB1F.asm
+++ b/data/wild/maps/PokemonMansionB1F.asm
@@ -28,3 +28,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/PokemonTower1F.asm
+++ b/data/wild/maps/PokemonTower1F.asm
@@ -4,3 +4,6 @@ PokemonTower1FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/PokemonTower2F.asm
+++ b/data/wild/maps/PokemonTower2F.asm
@@ -4,3 +4,6 @@ PokemonTower2FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/PokemonTower3F.asm
+++ b/data/wild/maps/PokemonTower3F.asm
@@ -14,3 +14,6 @@ PokemonTower3FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/PokemonTower4F.asm
+++ b/data/wild/maps/PokemonTower4F.asm
@@ -14,3 +14,6 @@ PokemonTower4FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/PokemonTower5F.asm
+++ b/data/wild/maps/PokemonTower5F.asm
@@ -14,3 +14,6 @@ PokemonTower5FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/PokemonTower6F.asm
+++ b/data/wild/maps/PokemonTower6F.asm
@@ -14,3 +14,6 @@ PokemonTower6FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/PokemonTower7F.asm
+++ b/data/wild/maps/PokemonTower7F.asm
@@ -14,3 +14,6 @@ PokemonTower7FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/PowerPlant.asm
+++ b/data/wild/maps/PowerPlant.asm
@@ -20,3 +20,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/RockTunnel1F.asm
+++ b/data/wild/maps/RockTunnel1F.asm
@@ -14,3 +14,6 @@ RockTunnel1FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/RockTunnelB1F.asm
+++ b/data/wild/maps/RockTunnelB1F.asm
@@ -14,3 +14,6 @@ RockTunnelB1FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/Route1.asm
+++ b/data/wild/maps/Route1.asm
@@ -14,3 +14,6 @@ Route1WildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/Route10.asm
+++ b/data/wild/maps/Route10.asm
@@ -25,3 +25,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, MAGIKARP
+	db 1, GOLDEEN
+	db 1, POLIWAG
+	db 1, GRIMER
+	db 1, GRIMER
+	db 1, GRIMER
+	db 1, GRIMER
+	db 1, GRIMER
+	db 1, GRIMER
+	db 1, GRIMER
+	end_fishing_wildmons

--- a/data/wild/maps/Route11.asm
+++ b/data/wild/maps/Route11.asm
@@ -25,3 +25,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, KRABBY
+	db 1, SHELLDER
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	end_fishing_wildmons

--- a/data/wild/maps/Route12.asm
+++ b/data/wild/maps/Route12.asm
@@ -28,3 +28,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, KRABBY
+	db 1, SHELLDER
+	db 1, HORSEA
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	end_fishing_wildmons

--- a/data/wild/maps/Route13.asm
+++ b/data/wild/maps/Route13.asm
@@ -28,3 +28,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, KRABBY
+	db 1, SHELLDER
+	db 1, HORSEA
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	end_fishing_wildmons

--- a/data/wild/maps/Route14.asm
+++ b/data/wild/maps/Route14.asm
@@ -26,3 +26,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/Route15.asm
+++ b/data/wild/maps/Route15.asm
@@ -26,3 +26,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/Route16.asm
+++ b/data/wild/maps/Route16.asm
@@ -14,3 +14,6 @@ Route16WildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/Route17.asm
+++ b/data/wild/maps/Route17.asm
@@ -14,3 +14,16 @@ Route17WildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, KRABBY
+	db 1, SHELLDER
+	db 1, HORSEA
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	end_fishing_wildmons

--- a/data/wild/maps/Route18.asm
+++ b/data/wild/maps/Route18.asm
@@ -14,3 +14,16 @@ Route18WildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, KRABBY
+	db 1, SHELLDER
+	db 1, HORSEA
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	db 1, STARYU
+	end_fishing_wildmons

--- a/data/wild/maps/Route19.asm
+++ b/data/wild/maps/Route19.asm
@@ -1,4 +1,4 @@
-SeaRoutesWildMons:
+Route19WildMons:
 	def_grass_wildmons 0 ; encounter rate
 	end_grass_wildmons
 
@@ -14,3 +14,16 @@ SeaRoutesWildMons:
 	db 35, TENTACOOL
 	db 40, TENTACOOL
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, KRABBY
+	db 1, SHELLDER
+	db 1, HORSEA
+	db 1, STARYU
+	db 1, KINGLER
+	db 1, KINGLER
+	db 1, KINGLER
+	db 1, KINGLER
+	db 1, KINGLER
+	db 1, KINGLER
+	end_fishing_wildmons

--- a/data/wild/maps/Route2.asm
+++ b/data/wild/maps/Route2.asm
@@ -23,3 +23,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/Route20.asm
+++ b/data/wild/maps/Route20.asm
@@ -1,15 +1,5 @@
-Route21WildMons:
-	def_grass_wildmons 25 ; encounter rate
-	db 21, RATTATA
-	db 23, PIDGEY
-	db 30, RATICATE
-	db 23, RATTATA
-	db 21, PIDGEY
-	db 30, PIDGEOTTO
-	db 32, PIDGEOTTO
-	db 28, TANGELA
-	db 30, TANGELA
-	db 32, TANGELA
+Route20WildMons:
+	def_grass_wildmons 0 ; encounter rate
 	end_grass_wildmons
 
 	def_water_wildmons 5 ; encounter rate
@@ -26,14 +16,14 @@ Route21WildMons:
 	end_water_wildmons
 
 	def_fishing_wildmons 1 ; encounter rate
-	db 1, KRABBY
 	db 1, SHELLDER
 	db 1, HORSEA
 	db 1, STARYU
-	db 1, KINGLER
-	db 1, KINGLER
-	db 1, KINGLER
-	db 1, KINGLER
-	db 1, KINGLER
-	db 1, KINGLER
+	db 1, TENTACOOL
+	db 1, TENTACRUEL
+	db 1, SEADRA
+	db 1, SEADRA
+	db 1, SEADRA
+	db 1, SEADRA
+	db 1, SEADRA
 	end_fishing_wildmons

--- a/data/wild/maps/Route22.asm
+++ b/data/wild/maps/Route22.asm
@@ -27,3 +27,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, MAGIKARP
+	db 1, GOLDEEN
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	end_fishing_wildmons

--- a/data/wild/maps/Route23.asm
+++ b/data/wild/maps/Route23.asm
@@ -24,3 +24,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, SLOWBRO
+	db 1, SEAKING
+	db 1, GOLDUCK
+	db 1, SEADRA
+	db 1, GYARADOS
+	db 1, DRATINI
+	db 1, DRATINI
+	db 1, DRATINI
+	db 1, DRATINI
+	db 1, DRATINI
+	end_fishing_wildmons

--- a/data/wild/maps/Route24.asm
+++ b/data/wild/maps/Route24.asm
@@ -25,3 +25,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, MAGIKARP
+	db 1, GOLDEEN
+	db 1, POLIWAG
+	db 1, SLOWPOKE
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	end_fishing_wildmons

--- a/data/wild/maps/Route25.asm
+++ b/data/wild/maps/Route25.asm
@@ -28,3 +28,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, MAGIKARP
+	db 1, GOLDEEN
+	db 1, POLIWAG
+	db 1, SLOWPOKE
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	db 1, PSYDUCK
+	end_fishing_wildmons

--- a/data/wild/maps/Route3.asm
+++ b/data/wild/maps/Route3.asm
@@ -14,3 +14,6 @@ Route3WildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/Route4.asm
+++ b/data/wild/maps/Route4.asm
@@ -25,3 +25,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, MAGIKARP
+	db 1, GOLDEEN
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	end_fishing_wildmons

--- a/data/wild/maps/Route5.asm
+++ b/data/wild/maps/Route5.asm
@@ -28,3 +28,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/Route6.asm
+++ b/data/wild/maps/Route6.asm
@@ -28,3 +28,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, MAGIKARP
+	db 1, GOLDEEN
+	db 1, POLIWAG
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	end_fishing_wildmons

--- a/data/wild/maps/Route7.asm
+++ b/data/wild/maps/Route7.asm
@@ -27,3 +27,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/Route8.asm
+++ b/data/wild/maps/Route8.asm
@@ -27,3 +27,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/Route9.asm
+++ b/data/wild/maps/Route9.asm
@@ -25,3 +25,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/SafariZoneCenter.asm
+++ b/data/wild/maps/SafariZoneCenter.asm
@@ -27,3 +27,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, PSYDUCK
+	db 1, SLOWPOKE
+	db 1, SEAKING
+	db 1, POLIWHIRL
+	db 1, GOLDUCK
+	db 1, SLOWBRO
+	db 1, GYARADOS
+	db 1, DRATINI
+	db 1, DRATINI
+	db 1, DRATINI
+	end_fishing_wildmons

--- a/data/wild/maps/SafariZoneEast.asm
+++ b/data/wild/maps/SafariZoneEast.asm
@@ -28,3 +28,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, PSYDUCK
+	db 1, SLOWPOKE
+	db 1, SEAKING
+	db 1, POLIWHIRL
+	db 1, GOLDUCK
+	db 1, SLOWBRO
+	db 1, GYARADOS
+	db 1, DRATINI
+	db 1, DRATINI
+	db 1, DRATINI
+	end_fishing_wildmons

--- a/data/wild/maps/SafariZoneNorth.asm
+++ b/data/wild/maps/SafariZoneNorth.asm
@@ -25,3 +25,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, PSYDUCK
+	db 1, SLOWPOKE
+	db 1, SEAKING
+	db 1, POLIWHIRL
+	db 1, GOLDUCK
+	db 1, SLOWBRO
+	db 1, GYARADOS
+	db 1, DRATINI
+	db 1, DRATINI
+	db 1, DRATINI
+	end_fishing_wildmons

--- a/data/wild/maps/SafariZoneWest.asm
+++ b/data/wild/maps/SafariZoneWest.asm
@@ -25,3 +25,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, PSYDUCK
+	db 1, SLOWPOKE
+	db 1, SEAKING
+	db 1, POLIWHIRL
+	db 1, GOLDUCK
+	db 1, SLOWBRO
+	db 1, GYARADOS
+	db 1, DRATINI
+	db 1, DRATINI
+	db 1, DRATINI
+	end_fishing_wildmons

--- a/data/wild/maps/SeafoamIslands1F.asm
+++ b/data/wild/maps/SeafoamIslands1F.asm
@@ -27,3 +27,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/SeafoamIslandsB1F.asm
+++ b/data/wild/maps/SeafoamIslandsB1F.asm
@@ -28,3 +28,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/SeafoamIslandsB2F.asm
+++ b/data/wild/maps/SeafoamIslandsB2F.asm
@@ -27,3 +27,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/SeafoamIslandsB3F.asm
+++ b/data/wild/maps/SeafoamIslandsB3F.asm
@@ -27,3 +27,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, KINGLER
+	db 1, STARYU
+	db 1, SHELLDER
+	db 1, SEEL
+	db 1, CLOYSTER
+	db 1, STARMIE
+	db 1, DEWGONG
+	db 1, DEWGONG
+	db 1, DEWGONG
+	db 1, DEWGONG
+	end_fishing_wildmons

--- a/data/wild/maps/SeafoamIslandsB4F.asm
+++ b/data/wild/maps/SeafoamIslandsB4F.asm
@@ -27,3 +27,16 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, KINGLER
+	db 1, STARYU
+	db 1, SHELLDER
+	db 1, SEEL
+	db 1, CLOYSTER
+	db 1, STARMIE
+	db 1, DEWGONG
+	db 1, DEWGONG
+	db 1, DEWGONG
+	db 1, DEWGONG
+	end_fishing_wildmons

--- a/data/wild/maps/VermilionCity.asm
+++ b/data/wild/maps/VermilionCity.asm
@@ -1,0 +1,19 @@
+VermilionCityWildMons:
+	def_grass_wildmons 0 ; encounter rate
+	end_grass_wildmons
+
+	def_water_wildmons 0 ; encounter rate
+	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, KRABBY
+	db 1, SHELLDER
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	end_fishing_wildmons

--- a/data/wild/maps/VermilionDock.asm
+++ b/data/wild/maps/VermilionDock.asm
@@ -1,0 +1,19 @@
+VermilionDockWildMons:
+	def_grass_wildmons 0 ; encounter rate
+	end_grass_wildmons
+
+	def_water_wildmons 0 ; encounter rate
+	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, KRABBY
+	db 1, SHELLDER
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	db 1, SLOWPOKE
+	end_fishing_wildmons

--- a/data/wild/maps/VictoryRoad1F.asm
+++ b/data/wild/maps/VictoryRoad1F.asm
@@ -14,3 +14,6 @@ VictoryRoad1FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/VictoryRoad2F.asm
+++ b/data/wild/maps/VictoryRoad2F.asm
@@ -14,3 +14,6 @@ VictoryRoad2FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/VictoryRoad3F.asm
+++ b/data/wild/maps/VictoryRoad3F.asm
@@ -14,3 +14,6 @@ VictoryRoad3FWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/ViridianCity.asm
+++ b/data/wild/maps/ViridianCity.asm
@@ -1,0 +1,19 @@
+ViridianCityWildMons:
+	def_grass_wildmons 0 ; encounter rate
+	end_grass_wildmons
+
+	def_water_wildmons 0 ; encounter rate
+	end_water_wildmons
+
+	def_fishing_wildmons 1 ; encounter rate
+	db 1, MAGIKARP
+	db 1, GOLDEEN
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	db 1, POLIWAG
+	end_fishing_wildmons

--- a/data/wild/maps/ViridianForest.asm
+++ b/data/wild/maps/ViridianForest.asm
@@ -26,3 +26,6 @@ ENDC
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/data/wild/maps/nothing.asm
+++ b/data/wild/maps/nothing.asm
@@ -4,3 +4,6 @@ NothingWildMons:
 
 	def_water_wildmons 0 ; encounter rate
 	end_water_wildmons
+
+	def_fishing_wildmons 0 ; encounter rate
+	end_fishing_wildmons

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -92,7 +92,7 @@ ItemUsePtrTable:
 	dw ItemUsePokeflute  ; POKE_FLUTE
 	dw UnusableItem      ; LIFT_KEY
 	dw UnusableItem      ; EXP_ALL
-	dw ItemUseSuperRod   ; SUPER_ROD
+	dw ItemUseFishingRod ; FISHING_ROD
 	dw ItemUsePPUp       ; PP_UP (real one)
 	dw ItemUsePPRestore  ; ETHER
 	dw ItemUsePPRestore  ; MAX_ETHER
@@ -1814,10 +1814,10 @@ CoinCaseNumCoinsText:
 	text_far _CoinCaseNumCoinsText
 	text_end
 
-ItemUseSuperRod:
+ItemUseFishingRod:
 	call FishingInit
 	jp c, ItemUseNotTime
-	call ReadSuperRodData
+	call ReadFishingRodData
 	ld a, e
 RodResponse:
 	ld [wRodResponse], a
@@ -1863,7 +1863,7 @@ FishingInit:
 	call PrintText
 	ld a, SFX_HEAL_AILMENT
 	call PlaySound
-	ld c, 80
+	ld c, 20
 	call DelayFrames
 	and a
 	ret
@@ -2795,13 +2795,13 @@ IsNextTileShoreOrWater:
 
 INCLUDE "data/tilesets/water_tilesets.asm"
 
-ReadSuperRodData:
+ReadFishingRodData:
 ; return e = 2 if no fish on this map
 ; return e = 1 if a bite, bc = level,species
 ; return e = 0 if no bite
 	ld a, [wCurMap]
 	ld de, 3 ; each fishing group is three bytes wide
-	ld hl, SuperRodData
+	ld hl, FishingRodData
 	call IsInArray
 	jr c, .ReadFishingGroup
 	ld e, $2 ; $2 if no fishing groups found
@@ -2822,12 +2822,9 @@ ReadSuperRodData:
 
 .RandomLoop
 	call Random
-	srl a
-	ret c ; 50% chance of no battle
-
-	and %11 ; 2-bit random number
+	and %1111 ; 4-bit random number
 	cp b
-	jr nc, .RandomLoop ; if a is greater than the number of mons, regenerate
+	ret nc ; if a is greater than the number of mons, miss
 
 	; get the mon
 	add a
@@ -2840,7 +2837,7 @@ ReadSuperRodData:
 	ld e, $1 ; $1 if there's a bite
 	ret
 
-INCLUDE "data/wild/super_rod.asm"
+INCLUDE "data/wild/fishing_rod.asm"
 
 ; reloads map view and processes sprite data
 ; for items that cause the overworld to be displayed
@@ -2869,6 +2866,9 @@ FindWildLocationsOfMon:
 	ld a, [hli]
 	and a
 	call nz, CheckMapForMon ; water
+	ld a, [hli]
+	and a
+	call nz, CheckMapForMon ; fishing
 	pop hl
 	inc hl
 	inc hl

--- a/engine/items/town_map.asm
+++ b/engine/items/town_map.asm
@@ -376,7 +376,7 @@ DisplayWildLocations:
 	ld a, [de]
 	cp $ff
 	jr z, .exitLoop
-	and a
+	cp $fa ; flag value for duplicate
 	jr z, .nextEntry
 	push hl
 	call LoadTownMapEntry
@@ -531,7 +531,8 @@ WriteSymmetricMonPartySpriteOAM:
 	ret
 
 ZeroOutDuplicatesInList:
-; replace duplicate bytes in the list of wild pokemon locations with 0
+; replace duplicate bytes in the list of wild pokemon locations with $FA
+; use $FA to refer to a non-existent map instead of 0, which is Pallet Town
 	ld de, wBuffer
 .loop
 	ld a, [de]
@@ -547,7 +548,7 @@ ZeroOutDuplicatesInList:
 	jr z, .loop
 	cp c
 	jr nz, .skipZeroing
-	xor a
+	ld a, $fa
 	ld [hl], a
 .skipZeroing
 	inc hl

--- a/macros/asserts.asm
+++ b/macros/asserts.asm
@@ -143,3 +143,21 @@ end_water_wildmons: MACRO
 			"def_water_wildmons {d:CURRENT_WATER_WILDMONS_RATE}: expected {d:WILDDATA_LENGTH} bytes"
 	ENDC
 ENDM
+
+def_fishing_wildmons: MACRO
+;\1: encounter rate
+CURRENT_FISHING_WILDMONS_RATE = \1
+REDEF CURRENT_FISHING_WILDMONS_LABEL EQUS "._def_fishing_wildmons_\1"
+{CURRENT_FISHING_WILDMONS_LABEL}:
+	db \1
+ENDM
+
+end_fishing_wildmons: MACRO
+	IF CURRENT_FISHING_WILDMONS_RATE == 0
+		ASSERT 1 == @ - {CURRENT_FISHING_WILDMONS_LABEL}, \
+			"def_fishing_wildmons {d:CURRENT_FISHING_WILDMONS_RATE}: expected 1 byte"
+	ELSE
+		ASSERT WILDDATA_LENGTH == @ - {CURRENT_FISHING_WILDMONS_LABEL}, \
+			"def_fishing_wildmons {d:CURRENT_FISHING_WILDMONS_RATE}: expected {d:WILDDATA_LENGTH} bytes"
+	ENDC
+ENDM

--- a/main.asm
+++ b/main.asm
@@ -67,21 +67,15 @@ INCLUDE "engine/pokemon/add_mon.asm"
 INCLUDE "engine/flag_action.asm"
 INCLUDE "engine/events/heal_party.asm"
 INCLUDE "engine/math/bcd.asm"
-INCLUDE "engine/movie/oak_speech/init_player_data.asm"
 INCLUDE "engine/items/get_bag_item_quantity.asm"
 INCLUDE "engine/overworld/pathfinding.asm"
-INCLUDE "engine/gfx/hp_bar.asm"
-INCLUDE "engine/events/hidden_objects/bookshelves.asm"
-INCLUDE "engine/events/hidden_objects/indigo_plateau_statues.asm"
-INCLUDE "engine/events/hidden_objects/book_or_sculpture.asm"
-INCLUDE "engine/events/hidden_objects/elevator.asm"
-INCLUDE "engine/events/hidden_objects/town_map.asm"
-INCLUDE "engine/events/hidden_objects/pokemon_stuff.asm"
+INCLUDE "engine/movie/oak_speech/init_player_data.asm"
 
 
 SECTION "Font Graphics", ROMX
 
 INCLUDE "gfx/font.asm"
+INCLUDE "engine/gfx/hp_bar.asm"
 
 
 SECTION "Battle Engine 1", ROMX
@@ -141,6 +135,12 @@ INCLUDE "engine/events/hidden_objects/cinnabar_gym_quiz.asm"
 INCLUDE "engine/events/hidden_objects/magazines.asm"
 INCLUDE "engine/events/hidden_objects/bills_house_pc.asm"
 INCLUDE "engine/events/hidden_objects/oaks_lab_email.asm"
+INCLUDE "engine/events/hidden_objects/bookshelves.asm"
+INCLUDE "engine/events/hidden_objects/indigo_plateau_statues.asm"
+INCLUDE "engine/events/hidden_objects/book_or_sculpture.asm"
+INCLUDE "engine/events/hidden_objects/elevator.asm"
+INCLUDE "engine/events/hidden_objects/town_map.asm"
+INCLUDE "engine/events/hidden_objects/pokemon_stuff.asm"
 
 
 SECTION "Bill's PC", ROMX

--- a/scripts/VermilionOldRodHouse.asm
+++ b/scripts/VermilionOldRodHouse.asm
@@ -15,7 +15,7 @@ VermilionHouse2Text1:
 	ld a, [wCurrentMenuItem]
 	and a
 	jr nz, .refused
-	lb bc, SUPER_ROD, 1
+	lb bc, FISHING_ROD, 1
 	call GiveItem
 	jr nc, .bag_full
 	ld hl, wd728


### PR DESCRIPTION
Rename Super Rod internally.
Move Fishing encounter data into wild mon encounter data for pokedex to pick it up and display.
Fix pokedex area not showing Pallet Town as nest location.
Remove Old and Good Rod from data.
Shuffle some stuff out of bank3 for room.